### PR TITLE
feat: adicionar armazenamento de logs e entrada simplificada de CEP

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,8 +23,8 @@ type ViaCEP struct {
 }
 
 func main() {
-	for _, url := range os.Args[1:] {
-		req, err := http.Get(url)
+	for _, cep := range os.Args[1:] {
+		req, err := http.Get("http://viacep.com.br/ws/" + cep + "/json/")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Erro ao fazer requisição: %v\n", err)
 		}
@@ -40,6 +40,14 @@ func main() {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Erro ao fazer parse da resposta: %v\n", err)
 		}
+		file, err := os.Create("cidade.txt")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Erro ao criar arquivo: %v\n", err)
+		}
+		defer file.Close()
+		_, err = file.WriteString(fmt.Sprintf("CEP: %s, Localidade %s, UF: %s, Bairro: %s", data.Cep, data.Localidade, data.Uf, data.Bairro))
+
+		fmt.Println("Arquivo de armazenamento criado com sucesso!")
 		fmt.Println(data)
 	}
 


### PR DESCRIPTION
# Descrição da Pull Request

## Objetivo:

- As informações de busca dos CEPs agora são armazenadas em um arquivo de texto (cidade.txt).
- Cada entrada no arquivo contém o CEP, localidade, UF e bairro.
- O programa agora aceita apenas o CEP como entrada, sem a necessidade de digitar a URL completa da API ViaCEP.
- A URL completa é gerada automaticamente no código.

## Modificações:

- Atualização do código no main.go para incluir a funcionalidade de armazenamento de logs.
- Modificação da lógica de entrada para aceitar apenas o CEP.